### PR TITLE
Mmandrus/fix up cli

### DIFF
--- a/cmd/clip.go
+++ b/cmd/clip.go
@@ -47,4 +47,6 @@ func init() {
 		`Use delim as the command delimiter character`)
 	clipCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",
 		`Filter tag`)
+	clipCmd.Flags().BoolVarP(&config.Flag.Color, "color", "", false,
+		`Enable colorized output (only fzf) (not working)`)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,7 +57,7 @@ func list(cmd *cobra.Command, args []string) error {
 		//	}
 		//} else {
 		//}
-		fmt.Fprintf(color.Output, "%12s \n", color.YellowString("    Commands:"))
+		fmt.Fprintf(color.Output, "%12s \n", color.YellowString("Example Commands:"))
 		for _, command := range snippet.Commands {
 			//fmt.Fprintf(color.Output, "%12s %s\n", color.YellowString("    Commands:"), command)
 			fmt.Println("    ", command)
@@ -65,12 +65,12 @@ func list(cmd *cobra.Command, args []string) error {
 		if snippet.Tag != nil {
 			tag := strings.Join(snippet.Tag, " ")
 			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.CyanString("        Tag:"), tag)
+				color.CyanString("Tag:"), tag)
 		}
 		if snippet.Output != "" {
 			output := strings.Replace(snippet.Output, "\n", "\n             ", -1)
 			fmt.Fprintf(color.Output, "%12s %s\n",
-				color.RedString("     Output:"), output)
+				color.RedString("Output:"), output)
 		}
 		fmt.Println(strings.Repeat("-", 30))
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -42,7 +42,7 @@ func search(cmd *cobra.Command, args []string) (err error) {
 func init() {
 	RootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().BoolVarP(&config.Flag.Color, "color", "", false,
-		`Enable colorized output (only fzf)`)
+		`Enable colorized output (only fzf) (not working)`)
 	searchCmd.Flags().StringVarP(&config.Flag.Query, "query", "q", "",
 		`Initial value for query`)
 	searchCmd.Flags().StringVarP(&config.Flag.FilterTag, "tag", "t", "",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -67,7 +67,7 @@ func filter(options []string, tag string) (commands []string, err error) {
 			if strings.ContainsAny(command, "\n") {
 				command = strings.Replace(command, "\n", "\\n", -1)
 			}
-			command = fmt.Sprintf(" $ %s", command)
+			command = fmt.Sprintf("$ %s", command)
 			formattedCommands = append(formattedCommands, command)
 			commandTexts[command] = s.Commands[i]
 		}
@@ -108,24 +108,29 @@ func filter(options []string, tag string) (commands []string, err error) {
 
 	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
 
-	params := dialog.SearchForParams(lines)
-	if params != nil {
-		snippetInfo := snippetHeadings[lines[0]]
-		dialog.CurrentCommand = snippetInfo.Commands[0] // TODO - does this need to be fixed?
-		dialog.GenerateParamsLayout(params, dialog.CurrentCommand)
-		res := []string{dialog.FinalCommand}
-		return res, nil
-	}
 	for _, line := range lines {
+		var command string
 		// first see if they selected a snippet heading
 		if snippetInfo, ok := snippetHeadings[line]; ok {
 			// default to first command
-			commands = append(commands, fmt.Sprint(snippetInfo.Commands[0]))
+			command = fmt.Sprint(snippetInfo.Commands[0])
 		} else if snippetText, ok := commandTexts[line]; ok {
-			commands = append(commands, fmt.Sprint(snippetText))
+			command = fmt.Sprint(snippetText)
 		} else {
 			fmt.Fprintf(color.Output, "\n%s: %s\n", color.HiRedString("unable to select command: "), line)
+			continue
 		}
+
+		// extract params from the original command
+		params := dialog.SearchForParams(command)
+		if params != nil {
+			dialog.CurrentCommand = command
+			dialog.GenerateParamsLayout(params, dialog.CurrentCommand)
+			res := []string{dialog.FinalCommand}
+			return res, nil
+		}
+
+		commands = append(commands, command)
 	}
 	return commands, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ type FlagConfig struct {
 	OneLine   bool
 	Color     bool
 	Tag       bool
+	Output    bool
 }
 
 // Load loads a config toml

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,7 @@ func (cfg *Config) Load(file string) error {
 		}
 	}
 	cfg.General.Column = 40
-	cfg.General.SelectCmd = "fzf"
+	cfg.General.SelectCmd = "fzf --reverse --ansi"
 	cfg.General.Backend = "gist"
 
 	cfg.Gist.FileName = "pet-snippet.toml"

--- a/dialog/params.go
+++ b/dialog/params.go
@@ -28,28 +28,25 @@ func insertParams(command string, params map[string]string) string {
 }
 
 // SearchForParams returns variables from a command
-func SearchForParams(lines []string) map[string]string {
+func SearchForParams(line string) map[string]string {
 	re := `<([\S].+?[\S])>`
-	if len(lines) == 1 {
-		r, _ := regexp.Compile(re)
+	r, _ := regexp.Compile(re)
 
-		params := r.FindAllStringSubmatch(lines[0], -1)
-		if len(params) == 0 {
-			return nil
-		}
-
-		extracted := map[string]string{}
-		for _, p := range params {
-			splitted := strings.Split(p[1], "=")
-			if len(splitted) == 1 {
-				extracted[p[0]] = ""
-			} else {
-				extracted[p[0]] = splitted[1]
-			}
-		}
-		return extracted
+	params := r.FindAllStringSubmatch(line, -1)
+	if len(params) == 0 {
+		return nil
 	}
-	return nil
+
+	extracted := map[string]string{}
+	for _, p := range params {
+		splitted := strings.Split(p[1], "=")
+		if len(splitted) == 1 {
+			extracted[p[0]] = ""
+		} else {
+			extracted[p[0]] = splitted[1]
+		}
+	}
+	return extracted
 }
 
 func evaluateParams(g *gocui.Gui, _ *gocui.View) error {


### PR DESCRIPTION
Better interaction with `list` and `new` commands
- format list view
- prompt for and handle output when using `pet new --output`

Better clip/search/exec interaction
- better formatting in the fzf view
- allow copying of sub-commands or top level snippet
- make params code less bad

note: clear out your `config.toml` file to get updated fzf config for better display